### PR TITLE
Added configuration option to gsheets plugin to rate limit api calls.…

### DIFF
--- a/gsheets/README.md
+++ b/gsheets/README.md
@@ -84,3 +84,21 @@ sheets:
     pages: 
       - sales
 ```
+
+### Limit the Google Sheets API Call Frequency
+
+If you are pulling data from more than a couple of sheets you will likely get this error due to too many concurrent api calls:
+
+```
+"Error occured while reloading source: AxiosError: Request failed with status code 429"
+```
+
+This can be prevented by specifying `ratelimtims` as an option in `connection.yaml`. 2500 works reliably.
+
+```
+name: google_sheet
+type: gsheets
+options: {ratelimitms: 2500}
+sheets:
+  id: 1Sc4nyLSSNETSIEpNKzheh5AFJJ-YA-wQeubFgeeEw9g
+```

--- a/gsheets/index.mjs
+++ b/gsheets/index.mjs
@@ -107,6 +107,8 @@ export async function* processSource(opts, files, utils) {
                 name: name + "_" + page.title.replaceAll(" ", "_").toLowerCase(),
                 content: name + "_" + page.title
             }
+
+            await new Promise(resolve => setTimeout(resolve, conn.options.ratelimitms ? conn.options.ratelimitms : 0)); // Delay each google sheets api call to prevent "Error occured while reloading source: AxiosError: Request failed with status code 429"
         }
     }
     return null


### PR DESCRIPTION
… This allows you to prevent the 429 error due to too many concurrent api calls

Discussed on slack:

https://evidencedev.slack.com/archives/C023LRB9Z40/p1716099704896269?thread_ts=1709916740.073449&cid=C023LRB9Z40

ratelimitms is an optional option in connections.yaml